### PR TITLE
Fix event listener being added too late

### DIFF
--- a/src/components/wrapper-for-404-redirects-from-github-pages.tsx
+++ b/src/components/wrapper-for-404-redirects-from-github-pages.tsx
@@ -25,15 +25,10 @@ export default function WrapperFor404RedirectsFromGitHubPages({ children }: Prop
 		if (ready)
 			return;
 
-		function readyStateChangeListener(): void {
-			setReady(isReady());
-		}
+		const actuallyReady = isReady();
 
-		document.addEventListener("readystatechange", readyStateChangeListener);
-
-		return (): void => {
-			document.removeEventListener("readystatechange", readyStateChangeListener);
-		};
+		if (ready !== actuallyReady)
+			setReady(actuallyReady);
 	}, [ ready, setReady ]);
 
 	if (triedPath != null && triedPath !== window.location.pathname)

--- a/src/components/wrapper-for-404-redirects-from-github-pages.tsx
+++ b/src/components/wrapper-for-404-redirects-from-github-pages.tsx
@@ -13,6 +13,7 @@ export default function WrapperFor404RedirectsFromGitHubPages({ children }: Prop
 	const location = useLocation();
 	const [ triedPath, setTriedPath ] = useState<string>();
 	const [ ready, setReady ] = useState(isReady());
+	const [ keepAlive, setKeepAlive ] = useState<number>();
 
 	useEffect(() => {
 		const tried = new URLSearchParams(location.search).get("tried");
@@ -29,7 +30,20 @@ export default function WrapperFor404RedirectsFromGitHubPages({ children }: Prop
 
 		if (ready !== actuallyReady)
 			setReady(actuallyReady);
-	}, [ ready, setReady ]);
+	}, [ ready, keepAlive ]);
+
+	useEffect(() => {
+		let timeoutID = setTimeout(function tick() {
+			setKeepAlive(Math.random());
+
+			if (!ready)
+				timeoutID = setTimeout(tick, 1000);
+		}, 1000);
+
+		return (): void => {
+			clearTimeout(timeoutID);
+		};
+	}, [ ready ]);
 
 	if (triedPath != null && triedPath !== window.location.pathname)
 		return <Redirect to={triedPath} />;


### PR DESCRIPTION
The issue was that on iOS for some reason the `"readystatechange"` event fired earlier than the event listener being added; therefore the event listener never fired and `ready` was never being set to `true`.

Fixed by continuously keeping value of `ready` up to date with value of `document.readyState` (not equal, just up to date), until `ready` is equal `true`